### PR TITLE
Include Change log in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ $ ./gradlew eclipse
 C:\> .\gradlew eclipse
 ```
 
+## Change log
+Change log is available [here](marathon-core/ChangeLog).
+
 ## More Information
 
 You can get more information about Marathon and documentation/support from:


### PR DESCRIPTION
The change log on https://marathontesting.com/ is not up to date, and the one in the codebase is not immediately accessible. It might be useful to have it linked to from the readme on the repo landing page.