### PR TITLE
JList construction should clear listeners.

### DIFF
--- a/marathon-java/marathon-java-agent/src/main/java/net/sourceforge/marathon/javaagent/components/JComboBoxOptionJavaElement.java
+++ b/marathon-java/marathon-java-agent/src/main/java/net/sourceforge/marathon/javaagent/components/JComboBoxOptionJavaElement.java
@@ -63,7 +63,9 @@ public class JComboBoxOptionJavaElement extends AbstractJavaElement implements I
         if (option >= model.getSize()) {
             throw new NoSuchElementException("Index out-of-bounds error on JComboBox: " + option, null);
         }
-        Component rendererComponent = comboBox.getRenderer().getListCellRendererComponent(new JList(model),
+        JList list = new JList(model);
+		list.setUI(null);
+		Component rendererComponent = comboBox.getRenderer().getListCellRendererComponent(list,
                 model.getElementAt(option), option, false, false);
         return rendererComponent;
     }


### PR DESCRIPTION
Basing a JList on an existing ComboBoxModel leads to registration of action listeners
on that model, we need to de-register them as well in order to prevent endless listener
registrations
![CallHierarchy](https://user-images.githubusercontent.com/7994707/164002273-2797527b-f859-42c7-8363-83eec9670e3b.png)

